### PR TITLE
Adaption for Fedora packaging.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -8,7 +8,7 @@ LDFLAGS = @LDFLAGS@
 VERSION = `git tag | tail -1 | sed -e 's/v//'`
 
 RM = rm -f
-INSTALL  = install -c
+INSTALL  = install -cp
 
 INCS = pgpdump.h
 SRCS = pgpdump.c types.c tagfuncs.c packet.c subfunc.c signature.c keys.c \
@@ -37,10 +37,10 @@ distclean:
 	$(RM) $(OBJS) $(PROG) $(CNF) $(MKF)
 
 install: all
-	$(INSTALL) -d $(bindir)
-	$(INSTALL) -m 555 $(PROG) $(bindir)
-	$(INSTALL) -d $(mandir)/man1
-	$(INSTALL) -m 444 $(MAN) $(mandir)/man1
+	$(INSTALL) -d $(DESTDIR)$(bindir)
+	$(INSTALL) -pm755 $(PROG) $(DESTDIR)$(bindir)
+	$(INSTALL) -d $(DESTDIR)$(mandir)/man1
+	$(INSTALL) -pm644 $(MAN) $(DESTDIR)$(mandir)/man1
 
 archive:
 	git archive master -o ~/pgpdump-$(VERSION).tar --prefix=pgpdump-$(VERSION)/


### PR DESCRIPTION
1. Preserve the timestamp.(Will help people to see the real time of files were generated)
2. Correct the permissions for standard. As far as I can tell you, 755 is the standard for binaries and 644 is the standard for non-executable files.
3. Add DESTDIR support as RPM needs to install files to a pseudo folder first which doesn't need to be granted any root access like /usr, and when we build RPMs we never use root to build.

PS: I'm packaging pgpdump for Fedora.
