### PR TITLE
Ignore whitespace when decoding Radix-64 input

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -33,6 +33,7 @@ private bz_stream bz;
 #define EOP -2
 #define ELF -3
 #define ECR -4
+#define SPC -5
 
 private unsigned int MAGIC_COUNT = 0;
 private unsigned int AVAIL_COUNT = 0;
@@ -49,11 +50,11 @@ private byte d_buf3[BUFSIZ];
 
 private signed char
 base256[] = {
-	OOB,OOB,OOB,OOB, OOB,OOB,OOB,OOB, OOB,OOB,ELF,OOB, OOB,ECR,OOB,OOB,
+	OOB,OOB,OOB,OOB, OOB,OOB,OOB,OOB, OOB,SPC,ELF,OOB, OOB,ECR,OOB,OOB,
 
 	OOB,OOB,OOB,OOB, OOB,OOB,OOB,OOB, OOB,OOB,OOB,OOB, OOB,OOB,OOB,OOB,
       /*                                                -                / */
-	OOB,OOB,OOB,OOB, OOB,OOB,OOB,OOB, OOB,OOB,OOB, 62, OOB,OOB,OOB, 63,
+	SPC,OOB,OOB,OOB, OOB,OOB,OOB,OOB, OOB,OOB,OOB, 62, OOB,OOB,OOB, 63,
       /*  0   1   2   3    4   5   6   7    8   9                =        */
 	 52, 53, 54, 55,  56, 57, 58, 59,  60, 61,OOB,OOB, OOB,EOP,OOB,OOB,
       /*      A   B   C    D   E   F   G    H   I   J   K    L   M   N   O*/
@@ -130,6 +131,8 @@ read_radix64(byte *p, unsigned int max)
 			continue;
 		case ECR:
 			if (++cr >= 2) goto skiptail;
+			continue;
+		case SPC:
 			continue;
 		}
 		lf = cr = 0;


### PR DESCRIPTION
[RFC4880](http://tools.ietf.org/html/rfc4880) section 6.4 states:

> In Radix-64 data, characters other than those in the table, line breaks, and other white space probably indicate a transmission error, about which a warning message or even a message rejection might be appropriate under some circumstances.  Decoding software must ignore all white space.

GnuPG ignores all white space, so it is able to successfully decrypt this unusual-but-compliant message (password is "test"):

```
-----BEGIN PGP MESSAGE-----
Version: GnuPG v1.4.11 (GNU/Linux)
Comment: Don't Panic

                          jA0EAwMCzTXKfBDG3MZg
                      yenU/HYHItLQi+pLW3dbXgVHTML
                   Z2oN7iRXvfIrdSPMaAji6uQuyhb4Xl0bT         n+   Oz UF
   a S 5K        O0dsRyNmocswEi5+mGHnp3xnSyUX7z6J5sM00P       u0 Qr YNPF
XK U i 2F      I4Wqmj7In4    QXKJ0u74oiBGM    dVmhAwwTgy       QHbABtKy
r0tSvwh44     HcKKxBuV1x      WPmYNDqjfzc      Q5fftRsawXX    aCucPTwR
  GkDzrPL    hNSxfjzov/A      3BUz4pb+VLA      pp9DL2cAd5sCPqi/BChRhu6
  sPJo3uiK0vOj4Qj/f5JNLgg    1lF5haqe+YFuD    yoSS/Fgx6q8DLd  qRR34z
   GynHzTUJrgB7AYz6hMrRnMV04aQf7bCm3cShnPIqg0T9A95s0e7oLOzOz     kCsm
    VS0   0WOSTnrgiOZZ224yozPwfS85fnYxaZ4LvY6WlXqhKV3NhIvhWcj     JYnTT
   UNcy   N4zQitub6LiBH5WueeU0cFbSnQ2u7IX5sMbK90JvHJoBT9QvG9i       JNb5
   VQI    F4jxcZEqkRf1gARCyILM/VkBucZPG7SW4kP7jsdyYjtjFF 8qgan9HHZS+YDdZml
  PR2gEf71yhEIi  JQGagp8TGT2xP2Js4jSuAJBs9i7CY47IZ+NGv   1JkkQUzpUO13u5R7aR
  jOKjR1vsyvkyO   LjmVxITDVHrzu/ey8Wz8S+KNwquBEj7zjO     VOwT6aza5sTR
 qB6Q       gWUJ    bRmTZ2zNsm70xF88qrMbkQNQ+hcpJ4      8Sf+
            teeKy     3gf2oYhKCPl4x8f+iHTxou1dB         tIw
              1chj          L2Hox6gt52XreWz           MrR8
               Z+jw7                                gk2Os
                tJW7M1      8Hy290Zp0S/GDY        4VL6r
                  Elg0tDhQ     jSoNVfu87Hg5/   9p6nDfM
                     BzN5G1+Gl8H  THsjAWLDA5wFAlnmZ
                        s6e+kSRDGWD zsTq0a6t5U
                                Jjd0Ku9NzHjVAH=
                                    wwS6
-----END PGP MESSAGE-----
```

However, pgpdump currently cannot parse it.  This patch changes pgpdump to ignore spaces and tabs, which fixes the problem.
