### PR TITLE
Add support for GnuPG extensions in private subkeys

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -188,6 +188,9 @@ plain_Secret_Key(int len)
 private void
 encrypted_Secret_Key(int len, int sha1)
 {
+	if (len == 0)
+		return;
+
 	switch (VERSION) {
 	case 2:
 	case 3:


### PR DESCRIPTION
This change adds detection of GnuPG extensions in private/experimental
S2K specifiers (type 101), and parsing of gnu-dummy (1001) (indicating
absent secret key material), and gnu-divert-to-card (2002) (indicating
key material stored on a smartcard).
# Example output
## Keyring with primary secret key removed

```
Old: Secret Key Packet(tag 5)(533 bytes)
        Ver 4 - new
        Public key creation time - Thu May 15 01:26:06 CEST 2014
        Pub alg - RSA Encrypt or Sign(pub 1)
        RSA n(4096 bits) - ...
        RSA e(17 bits) - ...
        Sym alg - CAST5(sym 3)
        GnuPG gnu-dummy (s2k 1001)
```
## Secret subkey transferred to smartcard

```
Old: Secret Subkey Packet(tag 7)(550 bytes)
        Ver 4 - new
        Public key creation time - Thu May 15 01:26:26 CEST 2014
        Pub alg - RSA Encrypt or Sign(pub 1)
        RSA n(4096 bits) - ...
        RSA e(17 bits) - ...
        Sym alg - CAST5(sym 3)
        GnuPG gnu-divert-to-card (s2k 1002)
        Serial Number: d2 76 00 01 24 01 02 00 00 05 00 00 1e 6d 00 00 
```
