### PR TITLE
Add simple shell test harness without massive haskell dependencies.

### DIFF
--- a/data/test.sh
+++ b/data/test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+[ X"$1" = X-v ] && verbose=true || verbose=false
+status=0
+
+for out in *.res; do
+	in=${out%.res}
+	diff=$(../pgpdump -u < "$in" | diff -au "$out" -)
+	if [ -n "$diff" ]; then
+		status=1
+		echo "$in FAIL"
+		$verbose && echo "$diff"
+	else
+		$verbose && echo "$in PASS"
+	fi
+done
+
+exit $status


### PR DESCRIPTION
It satisfies all the essential functionality, with the bonus of being able to actually be run by mere mortals!

Requires #13 (golden output conversion to UTC) for tests to pass.

This was motivated by wanting to create a MacPorts package for pgpdump, and wanting to reasonably be able to include the automated tests.
