### PR TITLE
Honor the CPPFLAGS variable from the environment.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,7 @@ CNF = config.h config.status config.cache config.log
 MKF = Makefile
 
 .c.o:
-	$(CC) -c $(CFLAGS) $<
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) $<
 
 all: $(PROG)
 


### PR DESCRIPTION
The autoconf build system suggests that C preprocessor flags (include
directories, defined/undefined symbols) should be passed in CPPFLAGS
instead of CFLAGS.  At least one OS packaging system (Debian dpkg)
passes some flags there, so add them to the C compilation command.

Thanks for taking care of pgpdump!