### PR TITLE
Autodetect compiler flags needed for Large File Support.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -21,4 +21,6 @@ AC_STRUCT_TIMEZONE
 
 dnl Checks for library functions.
 
+AC_SYS_LARGEFILE
+
 AC_OUTPUT(Makefile)


### PR DESCRIPTION
Thanks for taking care of pgpdump!