### PR TITLE
Evaluate and interpret "issuer fingerprint" subpackets

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -194,6 +194,7 @@ SIGSUB[] = {
         "features(sub 30)",
         "signature target(sub 31)",
 	"embedded signature(sub 32)",
+	"issuer fingerprint(sub 33)",
 };
 #define SIGSUB_NUM (sizeof(SIGSUB) / sizeof(string))
 
@@ -232,6 +233,7 @@ sigsub_func[] = {
         features,
         signature_target,
 	embedded_signature,
+	issuer_fingerprint,
 };
 
 private string

--- a/pgpdump.h
+++ b/pgpdump.h
@@ -153,6 +153,7 @@ public void reason_for_revocation(int);
 public void features(int);
 public void signature_target(int);
 public void embedded_signature(int);
+public void issuer_fingerprint(int);
 
 /*
  * uatfunc.c

--- a/subfunc.c
+++ b/subfunc.c
@@ -327,6 +327,25 @@ embedded_signature(int len)
 	Signature_Packet(len);
 }
 
+public void
+issuer_fingerprint(int len)
+{
+        int v = Getc();
+        len = len-1;
+	printf("\t v%d -", v);
+        if (v == 4) {
+          if (len != 20) {
+            printf(" had %d bytes, should have had 20\n", len);
+            skip(len);
+          } else {
+            fingerprint();
+          }
+        } else {
+          printf(" unknown version\n");
+          skip(len);
+        }
+}
+
 /*
  * Copyright (C) 1998 Kazuhiko Yamamoto
  * All rights reserved.


### PR DESCRIPTION
See the upcoming spec here:

https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-01#section-5.2.3.27

Modern versions of GnuPG issue these subpackets, so we should be able
to read them.