### PR TITLE
indicate unknown sigtype value is displayed in hex

### DIFF
--- a/signature.c
+++ b/signature.c
@@ -96,7 +96,7 @@ signature_type(int type)
 		printf("Third-Party Confirmation signature(0x50).");
 		break;
 	default:
-		printf("unknown(%02x)", type);
+		printf("unknown(0x%02x)", type);
 		break;
 	}
 	printf("\n");


### PR DESCRIPTION
All other sigtype values are shown with a leading 0x.  When an unknown
sigtype is encountered, it doesn't have the leading 0x, which is
confusing.

This change makes the output more consistent.

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>