### PR TITLE
Skip file to process when first/CTB is zero

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -61,8 +61,8 @@ old_Public_Key_Packet(void)
  *                    so that memcmp will work properly (compare two values of the same size)
  */
 private unsigned char BrainPool256r1_OID[10]={0x2B,0x24,0x3,0x3,0x2,0x8,0x1,0x1,0x7,0};
-private unsigned char BrainPool384r1_OID[10]={0x2B,0x24,0x3,0x3,0x2,0x8,0x1,0x1,0x0b,0};
-private unsigned char BrainPool512r1_OID[10]={0x2B,0x24,0x3,0x3,0x2,0x8,0x1,0x1,0x0d,0};
+private unsigned char BrainPool384r1_OID[10]={0x2B,0x24,0x3,0x3,0x2,0x8,0x1,0x1,0xb,0};
+private unsigned char BrainPool512r1_OID[10]={0x2B,0x24,0x3,0x3,0x2,0x8,0x1,0x1,0xd,0};
 private unsigned char NIST_P256_OID[10]={0x2A,0x86,0x48,0xCE,0x3D,0x3,0x1,0x7,0,0};
 private unsigned char NIST_P384_OID[10]={0x2B,0x81,0x04,0x00,0x22,0,0,0,0,0};
 private unsigned char NIST_P521_OID[10]={0x2B,0x81,0x04,0x00,0x23,0,0,0,0,0};
@@ -89,7 +89,7 @@ private struct {
   {Ed448_OID,"Ed448","0x2B 65 71"},
   {Curve25519_OID,"Curve25519","0x2B 06 01 04 01 97 55 01 05 01"},
   {X448_OID,"X448","0x2B 65 6F"},
-  {BrainPool256r1_OID,"brainpoolP256r1","0x2B 24 03 03 02 08 01 01 07"},
+  {BrainPool256r1_OID,"BrainPoolP256r1","0x2B 24 03 03 02 08 01 01 07"},
   {BrainPool384r1_OID,"BrainPoolP384r1","0x2B 24 03 03 02 08 01 01 07 0b"},
   {BrainPool512r1_OID,"BrainPoolP512r1","0x2B 24 03 03 02 08 01 01 07 0d"}
 };
@@ -125,7 +125,7 @@ new_Public_Key_Packet(int len)
 		break;
 	case 18:/*ECDH*/
 		oidLEN = Getc();
-		memset(oid_input_HEX,0,10);
+		memset(oid_input_HEX,0,oid_input_HEX_size);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -167,7 +167,7 @@ new_Public_Key_Packet(int len)
 		break;
 	case 19:/*ECDSA*/
 		oidLEN = Getc();
-		memset(oid_input_HEX,0,10);
+		memset(oid_input_HEX,0,oid_input_HEX_size);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -190,7 +190,7 @@ new_Public_Key_Packet(int len)
 		break;
         case 22:/*EdDSA*/
 		oidLEN = Getc();
-		memset(oid_input_HEX,0,10);
+		memset(oid_input_HEX,0,oid_input_HEX_size);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -307,7 +307,7 @@ plain_Secret_Key(int len)
 			break;
 	case 18:/*ECDH*/
 		oidLEN = Getc();
-		memset(oid_input_HEX,0,10);
+		memset(oid_input_HEX,0,oid_input_HEX_size);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -349,7 +349,7 @@ plain_Secret_Key(int len)
 		break;
 	case 19:/*ECDSA*/
 		oidLEN = Getc();
-		memset(oid_input_HEX,0,10);
+		memset(oid_input_HEX,0,oid_input_HEX_size);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -372,7 +372,7 @@ plain_Secret_Key(int len)
 		break;
         case 22:/*EdDSA*/
 		oidLEN = Getc();
-		memset(oid_input_HEX,0,10);
+		memset(oid_input_HEX,0,oid_input_HEX_size);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){

--- a/keys.c
+++ b/keys.c
@@ -125,6 +125,7 @@ new_Public_Key_Packet(int len)
 		break;
 	case 18:/*ECDH*/
 		oidLEN = Getc();
+		memset(oid_input_HEX,0,10);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -166,6 +167,7 @@ new_Public_Key_Packet(int len)
 		break;
 	case 19:/*ECDSA*/
 		oidLEN = Getc();
+		memset(oid_input_HEX,0,10);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -188,6 +190,7 @@ new_Public_Key_Packet(int len)
 		break;
         case 22:/*EdDSA*/
 		oidLEN = Getc();
+		memset(oid_input_HEX,0,10);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -304,6 +307,7 @@ plain_Secret_Key(int len)
 			break;
 	case 18:/*ECDH*/
 		oidLEN = Getc();
+		memset(oid_input_HEX,0,10);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -345,6 +349,7 @@ plain_Secret_Key(int len)
 		break;
 	case 19:/*ECDSA*/
 		oidLEN = Getc();
+		memset(oid_input_HEX,0,10);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){
@@ -367,6 +372,7 @@ plain_Secret_Key(int len)
 		break;
         case 22:/*EdDSA*/
 		oidLEN = Getc();
+		memset(oid_input_HEX,0,10);
 		for(jj=0;jj<oidLEN;jj++){oid_input_HEX[jj]=Getc();}
 	        for(jj=0;jj<ELLIP_CURVES_NUM;jj++){
 		  if(memcmp(ELLIP_CURVES[jj].oidhex,oid_input_HEX,oid_input_HEX_size) == 0){

--- a/packet.c
+++ b/packet.c
@@ -289,6 +289,14 @@ parse_packet(void)
 	c = getchar();
 	ungetc(c, stdin);
 
+	/* 2024-01-20 If the first byte is all zeros, then whatever
+	 * file is being examined is more than likely not an OpenPGP
+	 * key file. If it is/was a valid key file, then it has been
+	 * corrupted in some way where the first/CTB byte is not valid.
+	 */
+	if (c == 0)
+		warn_exit("Not a valid OpenPGP key file"); 
+
 	/* If the PGP packet is in the binary raw form, 7th bit of
 	 * the first byte is always 1. If it is set, let's assume
 	 * it is the binary raw form. Otherwise, let's assume


### PR DESCRIPTION
It is possible that someone could execute pgpdump against a non-key file which may begin with one or more "zero" bytes. It may also be possible that a legitimate "key file" is being used but its first/CTB byte has been "corrupted" and is now nothing more than "zero". In either case, if the first/CTB byte is "zero", then simply issue message and terminate processing. No need to do anymore work on the file.

Two sample "corrupted" key files and the normal/current pgpdump responses are attached:

[DSA_ELGAMAL_test.raw_prezerobytes.pubkey-pgpdump.zip](https://github.com/kazu-yamamoto/pgpdump/files/14001327/DSA_ELGAMAL_test.raw_prezerobytes.pubkey-pgpdump.zip)

[DSA_ELGAMAL_test.raw_prezerobytes.pubkey-armor-pgpdump.zip](https://github.com/kazu-yamamoto/pgpdump/files/14001328/DSA_ELGAMAL_test.raw_prezerobytes.pubkey-armor-pgpdump.zip)
