### PR TITLE
build: include COPYRIGHT in distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -O -Wall
-EXTRA_DIST =
+EXTRA_DIST = COPYRIGHT
 
 bin_PROGRAMS = pgpdump
 pgpdump_SOURCES = \


### PR DESCRIPTION
Since the switch to Automake, the generated tarball no longer includes the `COPYRIGHT` file. Automake automatically distributes `COPYING` by default, but does not recognize `COPYRIGHT`.

Add `COPYRIGHT` to `EXTRA_DIST` in `Makefile.am` to ensure it is included in the release.